### PR TITLE
Introduced custom Base64Error struct

### DIFF
--- a/src/base64_wrapper.rs
+++ b/src/base64_wrapper.rs
@@ -1,7 +1,32 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub struct Base64Error {
+    details: String
+}
+
+impl Base64Error {
+    fn new(msg: &str) -> Base64Error {
+        Base64Error{details: msg.to_string()}
+    }
+}
+
+impl fmt::Display for Base64Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.details)
+    }
+}
+
+impl From<base64::DecodeError> for Base64Error {
+    fn from(err: base64::DecodeError) -> Base64Error {
+        Base64Error::new(&err.to_string())
+    }
+}
+
 pub fn encode_base64(data: &[u8]) -> String {
     base64::encode(data)
 }
 
-pub fn decode_base64(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    base64::decode(encoded)
+pub fn decode_base64(encoded: &str) -> Result<Vec<u8>, Base64Error> {
+    base64::decode(encoded).map_err(Base64Error::from)
 }


### PR DESCRIPTION
A new error struct, Base64Error, has been introduced to handle base64 decoding errors. This struct includes a 'details' field for storing error messages and implements the Display trait for user-friendly output. The decode_base64 function now returns this custom error type instead of base64::DecodeError.